### PR TITLE
debian: also suppress python:any dependency

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -17,4 +17,4 @@ override_dh_python3:
 	dh_python3
 	# Remove python2 dep: this was only added due to mlnx_tune
 	# If users don't need mlnx_tune, they should not install python2
-	sed -i -e 's/python2:any, //' debian/mlnx-tools.substvars
+	sed -r -i -e 's/python2?:any(, |$$)//' debian/mlnx-tools.substvars


### PR DESCRIPTION
Also suppress python2 (mlnx_tune) generated dependency "python:any"
(older systems).

Also remove it when in end of line of sibstvars.

Signed-off-by: Tzafrir Cohen <nvidia@cohens.org.il>