### PR TITLE
tsbin/mlnx_bf_configure: Add ability for enabling IPsec full offload …

### DIFF
--- a/tsbin/mlnx_bf_configure
+++ b/tsbin/mlnx_bf_configure
@@ -159,6 +159,19 @@ enable_shared_rq_feature()
 	return 0;
 }
 
+get_ipsec_mode()
+{
+	pci_dev=$1
+	cat /sys/bus/pci/devices/${pci_dev}/net/*/compat/devlink/ipsec_mode 2> /dev/null
+}
+
+set_ipsec_mode()
+{   
+	pci_dev=$1
+	mode=$2
+	echo $mode > /sys/bus/pci/devices/${pci_dev}/net/*/compat/devlink/ipsec_mode 2> /dev/null
+}
+
 set_lag_hash_mode()
 {
 	pci_dev=$1
@@ -187,6 +200,7 @@ if [ -f /etc/mellanox/mlnx-bf.conf ]; then
 	. /etc/mellanox/mlnx-bf.conf
 fi
 ALLOW_SHARED_RQ=${ALLOW_SHARED_RQ:-"yes"}
+IPSEC_FULL_OFFLOAD=${IPSEC_FULL_OFFLOAD:-"no"}
 LAG_HASH_MODE=${LAG_HASH_MODE:-"no"}
 
 num_of_devs=0
@@ -213,6 +227,30 @@ do
 			set_steering_mode ${dev} smfs
 			RC=$((RC+$?))
 		fi
+
+		if [ "${IPSEC_FULL_OFFLOAD}" == "yes" ]; then
+			lscpu | grep Flags | grep sha1 | grep sha2 | grep -q aes
+			if [ $? -eq 0 ]; then
+				eswitch_mode=`get_eswitch_mode ${dev}`
+				if [ "${eswitch_mode}" == "switchdev" ]; then
+					set_eswitch_mode ${dev} legacy
+					RC=$((RC+$?))
+				fi
+				ipsec_mode=`get_ipsec_mode ${dev}`
+				if [ "$ipsec_mode" != "none" ]; then
+					set_ipsec_mode ${dev} none
+				fi
+				steering_mode=`get_steering_mode ${dev}`
+				if [ "${steering_mode}" == "smfs" ]; then
+					set_steering_mode ${dev} dmfs
+					RC=$((RC+$?))
+				fi
+				set_ipsec_mode ${dev} full
+			else
+				info "Crypto disabled on this devide. Skipping IPsec mode configuration."
+			fi
+		fi
+
 		eswitch_mode=`get_eswitch_mode ${dev}`
 		if [ "${eswitch_mode}" != "switchdev" ]; then
 			if [ "X${ALLOW_SHARED_RQ}" == "Xyes" ]; then


### PR DESCRIPTION
…on boot

Added the ability to enable IPsec full offload by
setting the IPSEC_FULL_OFFLOAD flag to "yes" in the
mlnx-bf.conf file

Signed-off-by: Emeel Hakim <ehakim@nvidia.com>