### PR TITLE
Fix mlnx_tune out of range tx number

### DIFF
--- a/ofed_scripts/utils/mlnx_tune
+++ b/ofed_scripts/utils/mlnx_tune
@@ -1954,11 +1954,12 @@ class InterfaceInfo( object ):
 		cmd = RINGS_CMD%(self.name)
 		( rc, output ) = getstatusoutput(cmd)
 		assert (not rc), "Unexpected error - cmd: %s bad exit status."%(cmd)
-		for line in output.split('\n'):
+		lines = output.split('\n')
+		for line in lines:
 			if ("rx-" in line ):
 				rx_ring = RingInfo(line.split('rx-')[1])
 				rx_ring.set_rps_mask(self.name)
-				if self.supports_xps:
+				if self.supports_xps and ('tx-'+rx_ring.number) in lines:
 					rx_ring.set_xps_mask(self.name)
 				rx_ring.irqs = rx_ring.get_irqs(self.name, rx_ring.number)
 				rings.append(rx_ring)


### PR DESCRIPTION
In order to use set_xps_mask in the get_rings function, there must
be an existing tx queue with the same number as the rx_ring object we
use the set_xps_mask on.
This commit fix the get_rings function.
The commit add a restriction to handle the out of range problem.

Signed-off-by: Shmuel Shaul <sshaul@nvidia.com>