### PR TITLE
tsbin/mlnx_bf_configure: fix switching to legacy mode

### DIFF
--- a/tsbin/mlnx_bf_configure
+++ b/tsbin/mlnx_bf_configure
@@ -226,7 +226,7 @@ do
 			set_lag_mode ${dev} "hash"
 		elif [ "X${LAG_MULTIPORT_ESW_MODE}" == "Xyes" ]; then
 			eswitch_mode=`get_eswitch_mode ${dev}`
-			if [ "${eswitch_mode}" == "switchdev" ]; then
+			if [ "${eswitch_mode}" != "legacy" ]; then
 				set_eswitch_mode ${dev} legacy
 				RC=$((RC+$?))
 			fi
@@ -236,7 +236,7 @@ do
 
 		if [ "X${ENCAP_NONE_MODE}" == "Xyes" ]; then
 			eswitch_mode=`get_eswitch_mode ${dev}`
-			if [ "${eswitch_mode}" == "switchdev" ]; then
+			if [ "${eswitch_mode}" != "legacy" ]; then
 				set_eswitch_mode ${dev} legacy
 				RC=$((RC+$?))
 			fi
@@ -247,7 +247,7 @@ do
 		steering_mode=`get_steering_mode ${dev}`
 		if [ "${steering_mode}" == "dmfs" ]; then
 			eswitch_mode=`get_eswitch_mode ${dev}`
-			if [ "${eswitch_mode}" == "switchdev" ]; then
+			if [ "${eswitch_mode}" != "legacy" ]; then
 				set_eswitch_mode ${dev} legacy
 				RC=$((RC+$?))
 			fi
@@ -260,7 +260,7 @@ do
 			lscpu | grep Flags | grep sha1 | grep sha2 | grep -q aes
 			if [ $? -eq 0 ]; then
 				eswitch_mode=`get_eswitch_mode ${dev}`
-				if [ "${eswitch_mode}" == "switchdev" ]; then
+				if [ "${eswitch_mode}" != "legacy" ]; then
 					set_eswitch_mode ${dev} legacy
 					RC=$((RC+$?))
 				fi


### PR DESCRIPTION
When first booted, the eswitch mode can be "none" instead
of legacy or switchdev.

Thus checking if the mode needs to be switched to legacy mode with
${eswitch_mode} == "switchdev"

does not work.

Instead check with:
${eswitch_mode} != "legacy"

Signed-off-by: Andy Roulin <andy.roulin@gmail.com>