### PR TITLE
mlnx_qos: Seperate buffer_size from prio2buffer commands

### DIFF
--- a/python/mlnx_qos
+++ b/python/mlnx_qos
@@ -241,7 +241,10 @@ def set_prio2buffer_sysfs(buffer):
 
 def get_buffer_size_sysfs():
 	f = open(buffer_size_path, "r")
-	buffer = array.array('I', [0,0,0,0,0,0,0,0])
+	buffer = array.array('I', [0,0,0,0,0,0,0,0,0])
+	first_line =  f.readline()
+	data = first_line.split('=')
+	total_size = int(data[1])
 	next(f)
 	next(f)
 	next(f)
@@ -251,6 +254,7 @@ def get_buffer_size_sysfs():
 		size = int(data[1])
 		buffer[buf] = size
 	f.close()
+	buffer[8] = total_size
 	return buffer
 
 def set_buffer_size_sysfs(buffer):
@@ -540,7 +544,7 @@ try:
 	if (is_buffer_sysfs):
 		prio2buffer = get_prio2buffer_sysfs()
 		buffer_size = get_buffer_size_sysfs()
-		tot_size = None
+		tot_size = buffer_size[8]
 	else:
 		prio2buffer, buffer_size, tot_size = ctrl.get_ieee_dcb_buffer()
 
@@ -578,11 +582,13 @@ try:
 
 	if options.buffer_size or options.prio2buffer:
 		if (is_buffer_sysfs):
-			set_prio2buffer_sysfs(prio2buffer)
-			set_buffer_size_sysfs(buffer_size)
-			prio2buffer = get_prio2buffer_sysfs()
-			buffer_size = get_buffer_size_sysfs()
-			tot_size = None
+			if (options.buffer_size):
+				set_buffer_size_sysfs(buffer_size)
+				buffer_size = get_buffer_size_sysfs()
+				tot_size = buffer_size[8]
+			else:
+				set_prio2buffer_sysfs(prio2buffer)
+				prio2buffer = get_prio2buffer_sysfs()
 		else:
 			ctrl.set_dcb_buffer(_prio2buffer = prio2buffer, _buffer_size = buffer_size,
 					    _tot_size = tot_size)


### PR DESCRIPTION
Curerntly, with each buffer_size or prio2buffer command the script triggers the logic of both operations regardless of which one was called via the user.

Seperate the two flows, and trigger only the necessary functionality when requested from user.

Signed-off-by: Maher Sanalla <msanalla@nvidia.com>