### PR TITLE
Avoid the "python(abi)" rpm generated requirement

### DIFF
--- a/mlnx-tools.spec
+++ b/mlnx-tools.spec
@@ -50,6 +50,8 @@ Mellanox userland tools and scripts
 %if %{PYTHON3}
 %define __python %{_bindir}/python3
 BuildRequires: python3
+# python(abi) . "(abi)" seems to be is tricky to get through shell quoting.
+%define __requires_exclude ^python
 %endif
 
 %prep


### PR DESCRIPTION
Make the rpm package more portable for different python versions in the same distribution:

Currently there is one script, mlnx_qos, that uses python modules from a python-version-specific directory. The 'python(abi)' dependency is created because of that.

Avoid creating it, as the expense of potentially breaking mlnx_qos on such systems, but at least being able to install mlnx-tools.

Issue: 3431430