### PR TITLE
tsbin/mlnx_bf_configure: Remove unavailable devlink params for upstre…

### DIFF
--- a/tsbin/mlnx_bf_configure
+++ b/tsbin/mlnx_bf_configure
@@ -28,7 +28,6 @@
 # and/or other materials provided with the distribution.
 
 PATH=/opt/mellanox/iproute2/sbin:/opt/mellanox/ethtool/sbin:/bin:/sbin:/usr/bin:/usr/sbin
-CT_MAX_OFFLOADED_CONNS=${CT_MAX_OFFLOADED_CONNS:-1000000}
 
 RC=0
 
@@ -181,7 +180,6 @@ fi
 if [ -f /etc/mellanox/mlnx-bf.conf ]; then
 	. /etc/mellanox/mlnx-bf.conf
 fi
-ALLOW_SHARED_RQ=${ALLOW_SHARED_RQ:-"yes"}
 IPSEC_FULL_OFFLOAD=${IPSEC_FULL_OFFLOAD:-"no"}
 LAG_HASH_MODE=${LAG_HASH_MODE:-"yes"}
 
@@ -254,17 +252,12 @@ do
 
 		eswitch_mode=`get_eswitch_mode ${dev}`
 		if [ "${eswitch_mode}" != "switchdev" ]; then
-			if [ "X${ALLOW_SHARED_RQ}" == "Xyes" ]; then
-				set_dev_param ${dev} esw_pet_insert true "Shared RQ:"
-			fi
 			if [ "X${LEGACY_METADATA_MATCH_MODE}" == "Xyes" ]; then
 				set_dev_param ${dev} vport_match_mode legacy
 			fi
 
 			set_eswitch_mode ${dev} switchdev
 			RC=$((RC+$?))
-
-			set_dev_param ${dev} ct_max_offloaded_conns ${CT_MAX_OFFLOADED_CONNS}
 		fi
 		eswitch_mode=`get_eswitch_mode ${dev}`
 		if [ "${eswitch_mode}" == "switchdev" ]; then


### PR DESCRIPTION
…am kernel

Shared RQ and max CT connections are only available for MOFED, but they'll be triggered as default and cause warning. Remove them for cleanness.