### PR TITLE
tsbin/mlnx_bf_configure: Ignore set_steering_mode status

### DIFF
--- a/tsbin/mlnx_bf_configure
+++ b/tsbin/mlnx_bf_configure
@@ -236,7 +236,6 @@ do
 			fi
 
 			set_steering_mode ${dev} smfs
-			RC=$((RC+$?))
 		fi
 
 		if [ "${IPSEC_FULL_OFFLOAD}" == "yes" ]; then
@@ -254,7 +253,6 @@ do
 				steering_mode=`get_steering_mode ${dev}`
 				if [ "${steering_mode}" == "smfs" ]; then
 					set_steering_mode ${dev} dmfs
-					RC=$((RC+$?))
 				fi
 				set_dev_param ${dev} ipsec_mode full
 			else


### PR DESCRIPTION
Set steering mode returns an error if the operation is not supported but this does not mean that the script cannot continue to work with the default steering mode.