### PR TITLE
tsbin/mlnx_bf_configure: Add retry for mlxconfig

### DIFF
--- a/tsbin/mlnx_bf_configure
+++ b/tsbin/mlnx_bf_configure
@@ -163,6 +163,54 @@ set_dev_param()
 	return $rc
 }
 
+run_mlxconfig()
+{
+	cmd="$*"
+	mft_output=""
+
+	SECONDS=0
+	mft_output="$($cmd 2>&1)"
+	while (echo "$mft_output" | grep -q "Failed to open"); do
+		if [ $SECONDS -gt $MLXCONFIG_TIMEOUT ]; then
+			error "Failed to run $cmd"
+			exit 1
+		fi
+		sleep 1
+		mft_output=$($cmd 2>&1)
+	done
+	echo "$mft_output"
+}
+
+is_port_ib()
+{
+	dev=$1
+	port=$2
+	shift 2
+
+	mft_output=$(run_mlxconfig "$mftconfig -d ${dev} -e q LINK_TYPE_P$port")
+
+	if (echo "$mft_output" | grep -o LINK_TYPE_P.* | awk '{print $3}' | grep -q "IB(1)"); then
+		return 0
+	fi
+	return 1
+}
+
+is_smartnic_mode()
+{
+	dev=$1
+	port=$2
+	shift 2
+
+	mft_output=$(run_mlxconfig "$mftconfig -d ${dev} -e q ECPF_ESWITCH_MANAGER")
+
+	if (echo $mft_output | grep -o ECPF_ESWITCH_MANAGER.* | awk '{print$3}' | grep -q "ECPF(1)"); then
+		info "Device ${dev} is in SmartNIC mode"
+		return 0
+	fi
+	info "Device ${dev} is in SEPERATED_HOST mode"
+	return 1
+}
+
 is_SecureBoot=0
 if (mokutil --sb-state 2>&1 | grep -q "SecureBoot enabled"); then
 	is_SecureBoot=1
@@ -201,12 +249,12 @@ do
 	done
 
 	port=$(( ${dev: -1} + 1 ))
-	if ($mftconfig -d ${dev} -e q LINK_TYPE_P$port 2> /dev/null | grep -o LINK_TYPE_P.* | awk '{print $3}' | grep -q "IB(1)"); then
+	if (is_port_ib "$dev" "$port"); then
 		info "Link type is IB for ${dev}. Skipping mode confiugration."
 		continue
 	fi
 
-	if ($mftconfig -d ${dev} -e q ECPF_ESWITCH_MANAGER 2> /dev/null | grep -o ECPF_ESWITCH_MANAGER.* | awk '{print$3}' | grep -q "ECPF(1)"); then
+	if (is_smartnic_mode "$dev" "$port"); then
 		if [ "X${LAG_HASH_MODE}" == "Xno" ]; then
 			set_dev_param ${dev} lag_port_select_mode queue_affinity
 		elif [ "X${LAG_MULTIPORT_ESW_MODE}" == "Xyes" ]; then
@@ -382,7 +430,7 @@ done
 
 ovsbr_number=`$vsctl list-br | wc -l`
 if [ $ovsbr_number -gt 0 ]; then
-	if ($vsctl get Open_vSwitch . Other_config 2> /dev/null | grep 'hw-offload="true"'); then
+	if ($vsctl get Open_vSwitch . Other_config 2> /dev/null | grep -q 'hw-offload="true"'); then
 		ovs_restart
 	fi
 	exit $RC


### PR DESCRIPTION
In some cases mlxconfig fails with "Failed to open device" error. Try to rerun mlxconfig command with MLXCONFIG_TIMEOUT which is 60 seconds by default.