### PR TITLE
tsbin/mlnx_bf_configure: Use systemctl to restart openvswitch service

### DIFF
--- a/tsbin/mlnx_bf_configure
+++ b/tsbin/mlnx_bf_configure
@@ -432,11 +432,7 @@ if ! (systemctl is-enabled $ovs_service 2> /dev/null | grep -wq enabled); then
 	exit 0
 fi
 
-if [ "$ovs_service" == "openvswitch-switch.service" ]; then
-	ovs_restart="/etc/init.d/openvswitch-switch restart"
-else
-	ovs_restart="systemctl restart $ovs_service"
-fi
+ovs_restart="systemctl restart $ovs_service"
 
 ovs_restart()
 {


### PR DESCRIPTION
Don't use directly the init.d script to avoid systemctl inconsistent state. There is no reason as systemctl is supported where we use mlnx_bf_configure.

systemctl status can show active(running) when openvswitch started through it, e.g. at boot, but when mlnx_bf_configure script restarts openvswitch through the init.d script the systemctl status becomes active(exit).

There is no real bug or issue with openvswitch itself but this is just to avoid the inconsistent systemctl status reported.

Issue: 3765486