### PR TITLE
Decode bytes before running string operations on the same

### DIFF
--- a/python/tc_wrap.py
+++ b/python/tc_wrap.py
@@ -53,7 +53,7 @@ class skprio2up:
 	                        "* 2> /dev/null", shell=True, bufsize=4096,
 	                        stdout=PIPE).stdout
 	        for line in output:
-	                param, val = line.decode("utf-8").strip().split(":", 1)
+	                param, val=line.decode("utf-8").strip().split(":", 1)
 	                vlan = param.split('.')[-1]
 	                for item in val.split(":", 1)[1].split():
 	                        skprio, up = item.split(':')

--- a/python/tc_wrap.py
+++ b/python/tc_wrap.py
@@ -53,7 +53,7 @@ class skprio2up:
 	                        "* 2> /dev/null", shell=True, bufsize=4096,
 	                        stdout=PIPE).stdout
 	        for line in output:
-	                param, val=line.strip().split(":", 1)
+	                param, val = line.decode("utf-8").strip().split(":", 1)
 	                vlan = param.split('.')[-1]
 	                for item in val.split(":", 1)[1].split():
 	                        skprio, up = item.split(':')
@@ -150,7 +150,7 @@ class tcnum_mqprio(tcnum):
 
 		for line in output:
 			empty=False
-			m = re.search(r'tc (\d)', line)
+			m = re.search(r'tc (\d)', line.decode("utf-8"))
 			if m:
 				self.tc_num = m.group(1)
 


### PR DESCRIPTION
Post execution of grep on vlan information for interface and when tc tool is executed get qdisc information for the device, the bytes must be converted to string to run split and regex. 

resolve: #84 