### PR TITLE
Don't remove existing directory

### DIFF
--- a/sbin/cma_roce_mode
+++ b/sbin/cma_roce_mode
@@ -87,12 +87,15 @@ fi
 
 cd rdma_cm
 
+need_clean=0
+
 if [ ! -d $DEVICE ]; then
 	mkdir $DEVICE
 	if [ $? -ne 0 ]; then
 		echo "Failed to create configuration for $DEVICE"
 		exit 1
 	fi
+	need_clean=1
 fi
 
 if [ ! -d $DEVICE/ports/$PORT ]; then
@@ -110,6 +113,6 @@ fi
 cat default_roce_mode
 
 cd ../../..
-rmdir $DEVICE
+[[ "$need_clean" -eq 1 ]] && rmdir $DEVICE
 
 exit 0

--- a/sbin/cma_roce_tos
+++ b/sbin/cma_roce_tos
@@ -88,12 +88,15 @@ fi
 
 cd rdma_cm
 
+need_clean=0
+
 if [ ! -d $DEVICE ]; then
 	mkdir $DEVICE
 	if [ $? -ne 0 ]; then
 		echo "Failed to create configuration for $DEVICE"
 		exit 1
 	fi
+	need_clean=1
 fi
 
 if [ ! -d $DEVICE/ports/$PORT ]; then
@@ -109,6 +112,6 @@ fi
 cat default_roce_tos
 
 cd ../../..
-rmdir $DEVICE
+[[ "$need_clean" -eq 1 ]] && rmdir $DEVICE
 
 exit 0


### PR DESCRIPTION
In the case if rdma_cm/<DEV> device directory exist before the script execution, prevent removing the directory on the exit.

That happens when end-user use OS vendor instructions how to set RoCE mode or configure tos and expect device directory to be present all the time.
Running cma_roce script removes that folder leads to unexpected system configuration change.

https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_infiniband_and_rdma_networks/configuring-roce_configuring-infiniband-and-rdma-networks

Another example is running multiple instances of the scripts at the same time. It leads to race conditions when one script creates the folder, but the other destroys it before first instance is trying to write to the folder.
