### PR TITLE
mlnx-sf: Move port show out of init

### DIFF
--- a/tsbin/mlnx-sf
+++ b/tsbin/mlnx-sf
@@ -81,6 +81,11 @@ class SF:
         self.info = {}
         self.info_error = 0
 
+
+    def show(self):
+        """
+        Show configurations
+        """
         # Get existing devices
         cmd = MLXDEVM + " --pretty --json port show "
         if self.sfindex:
@@ -91,11 +96,6 @@ class SF:
             return
         self.info = json.loads(output)
 
-
-    def show(self):
-        """
-        Show configurations
-        """
         result = {'status': self.info_error, 'output': 'No SF device found'}
 
         if not self.info:


### PR DESCRIPTION
When creating > 500 sf using mlnx-sf one-by-one, every initialization of mlnx-sf issues "mlxdevm port show", which takes longer and longer time when existing number of SFs increases. In our experiments on BF2, with existing ~400 SFs, creating 1 SF takes around 10sec:
 $ mlnx-sf -d 0000:03:00.0 -a create -n 440
 Created SF: index=pci/0000:03:00.0/229718 hw_addr=00:00:00:00:00:00 \
 sfnum=440 netif=eth0
	real	0m10.214s
	user	0m0.193s
	sys	0m0.301s
And profiling shows majority of time spent in python init. With the patch, the time reduces to around 5 seconds.

--- attach two frame graph ---
see
perf-100: 100 existing SFs, 31% on _start(), 27% on mlxdevm
perf-400: 400 existing SF, 69% on _start(), 23% on mlxdevm
![perf-400](https://github.com/Mellanox/mlnx-tools/assets/5173499/3b9de975-12e5-4245-b85e-7c64fe679b0c)
![perf-100](https://github.com/Mellanox/mlnx-tools/assets/5173499/e9eefa8b-835d-46d2-90c5-e8514e08ac07)

 