### PR TITLE
tsbin/mlnx_bf_configure: Add indication that the script was done

### DIFF
--- a/tsbin/mlnx_bf_configure
+++ b/tsbin/mlnx_bf_configure
@@ -551,6 +551,9 @@ if [ "X${OVS_HW_OFFLOAD}" == "Xyes" ]; then
 fi
 } &
 
+#Indication that the script has finished and other underlying services can start
+systemctl stop --no-block mlnx_bf_configure_sync
+
 sync
 
 exit $RC


### PR DESCRIPTION
In some cases like HBN, OVS will try to start while mlnx_bf_configure is still running and changing eswitch mode, this will can cause a race and to OVS to crash.

This change add an indication that mlnx_bf_configure finished so OVS service will wait on.

Issue: 3963483