### PR TITLE
tsbin/mlnx-sf: Wait for SF config driver to load

### DIFF
--- a/tsbin/mlnx-sf
+++ b/tsbin/mlnx-sf
@@ -46,6 +46,8 @@ DEVLINK = 'devlink'
 SUPPORTED_ACTIONS=["create", "show", "delete"]
 RDMA_DEV_TIMEOUT = 120
 DEVLINK_DEV_TIMEOUT = 20
+SF_CFG_DRIVER_TIMEOUT = 20
+
 verbose = False
 
 if os.path.exists("/usr/bin/mlxconfig"):
@@ -208,6 +210,15 @@ class SF:
                 break
             self.aux_dev = lookup_aux_dev(self.device, self.sfnum)
             if self.aux_dev:
+                break
+            time.sleep(0.001)
+
+        # Wait for sf_cfg link to be created
+        start = time.process_time()
+        while True:
+            if time.process_time() - start > SF_CFG_DRIVER_TIMEOUT:
+                break
+            if os.path.basename(os.readlink("/sys/bus/auxiliary/devices/{}/driver".format(self.aux_dev))) == "mlx5_core.sf_cfg":
                 break
             time.sleep(0.001)
 


### PR DESCRIPTION
As a part of the SF probing, the user should unbind the SF from the default config driver and bind the actual SF driver. Make the script wait 20 seconds for the config driver to load, so SF probing on startup will be more resilient.

Issue: 3956110