### PR TITLE
udev scripts: Prevent 82-net-setup-link.rules from setting invalid NAME

### DIFF
--- a/udev/rules.d/82-net-setup-link.rules
+++ b/udev/rules.d/82-net-setup-link.rules
@@ -1,12 +1,12 @@
 SUBSYSTEM=="net", NAME=="side-*-eth[0-9]*", GOTO="net_setup_skip_link_name"
 
 SUBSYSTEM=="net", ACTION=="add", ATTR{phys_switch_id}!="", ATTR{phys_port_name}!="", ATTR{phys_port_name}!="*pf*sf*" \
-        IMPORT{program}="/lib/udev/vf-net-link-name.sh $attr{phys_port_name} $attr{phys_switch_id} $attr{ifindex}" \
+        IMPORT{program}="/lib/udev/vf-net-link-name.sh $name $attr{phys_port_name} $attr{phys_switch_id} $attr{ifindex}" \
         NAME="$env{NAME}", RUN+="/lib/udev/mlnx_bf_udev $env{NAME}", GOTO="net_setup_skip_link_name"
 
 
 SUBSYSTEM=="net", ACTION=="add", ATTR{phys_port_name}!="", ATTR{phys_port_name}!="*pf*sf*" \
-        IMPORT{program}="/lib/udev/vf-net-link-name.sh $attr{phys_port_name}" \
+        IMPORT{program}="/lib/udev/vf-net-link-name.sh $name $attr{phys_port_name}" \
         NAME="$env{NAME}", RUN+="/lib/udev/mlnx_bf_udev $env{NAME}"
 
 LABEL="net_setup_skip_link_name"

--- a/udev/scripts/vf-net-link-name.sh
+++ b/udev/scripts/vf-net-link-name.sh
@@ -1,21 +1,24 @@
 #!/bin/bash
 
-SWID=$2
+ORIG_NAME=$1
+SWID=$3
 # might be pf0vf1 so only get vf number
-PORT=${1##*f}
-PORT_NAME=`echo ${1} | sed -e "s/c[[:digit:]]\+//"`
-IFINDEX=$3
+PORT=${2##*f}
+PORT_NAME=`echo ${2} | sed -e "s/c[[:digit:]]\+//"`
+IFINDEX=$4
 
 # need the PATH for BF ARM lspci to work
 PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin
 
 is_bf=`lspci -s 00:00.0 2> /dev/null | grep -wq "PCI bridge: Mellanox Technologies" && echo 1 || echo 0`
 if [ $is_bf -ne 1 ]; then
+        echo "NAME=$ORIG_NAME"
 	exit 0
 fi
 
 if [[ "$ID_NET_DRIVER" != *"mlx5"* ]]; then
-    exit 1
+        echo "NAME=$ORIG_NAME"
+        exit 1
 fi
 
 function get_mh_bf_rep_name() {


### PR DESCRIPTION
The 82-net-setup-link.rules UDEV rule calls vf-net-link-name.sh and then sets NAME="$env{NAME}". But in some cases, vf-net-link-name.sh does not return "NAME" and the result is error messages such as:

"systemd-udevd[164885]: Error changing net interface name 'eth101' to '': Invalid argument"

Additionally, this can break other UDEV rules that run after 82-net-setup-link.rules. vf-net-link-name.sh should always return a valid interface name.

Fixes: d7adfdf549f2 ("udev scripts: Support network interfaces rename on DPU only")