### PR TITLE
mlnx_bf_configure: Add missing OVS restart.

### DIFF
--- a/tsbin/mlnx_bf_configure
+++ b/tsbin/mlnx_bf_configure
@@ -604,6 +604,9 @@ fi
 
 CREATE_OVS_BRIDGES=${CREATE_OVS_BRIDGES:-"yes"}
 if [ "X${CREATE_OVS_BRIDGES}" != "Xyes" ]; then
+    if [ "$need_restart" == true ]; then
+		ovs_restart
+    fi
 	exit $RC
 fi
 


### PR DESCRIPTION
The referenced commit enabled OVS-DOCA configuration from the mlnx_bf_configure script, which requires an OVS restart. Currently if CREATE_OVS_BRIDGES flag is not set to "yes" the script exits without restarting This fix ensures that OVS is restarted even when
CREATE_OVS_BRIDGES is not set to "yes", by checking if a restart is necessary before exiting.

Issue: 4357112
Fixes: b20462ab1b14 ("mlnx_bf_configure: Enable OVS-DOCA as the default switch for BlueField")