### PR TITLE
mlnx_bf_configure: Cleanup hugepages for invalid OVS_DOCA values.

### DIFF
--- a/tsbin/mlnx_bf_configure
+++ b/tsbin/mlnx_bf_configure
@@ -442,7 +442,7 @@ config_hugepages()
 
 cleanup_hugepages()
 {
-	if [ "X${OVS_DOCA}" == "Xno" ] && $HUGEPAGES_TOOL show | grep -q "ovs-doca"; then
+	if [ "X${OVS_DOCA}" != "Xyes" ] && $HUGEPAGES_TOOL show | grep -q "ovs-doca"; then
 		info "Removing ovs-doca default hugepages configuration"
 		$HUGEPAGES_TOOL remove ovs-doca
 		$HUGEPAGES_TOOL reload


### PR DESCRIPTION
Currently, hugepages are cleaned up for OVS-DOCA only when OVS_DOCA is set to "no". To handle invalid values, we should revert to the default "no" and cleanup hugepages.