### PR TITLE
tsbin/mlnx-sf: Fix mlnx-sf -a show command: sfnum

### DIFF
--- a/tsbin/mlnx-sf
+++ b/tsbin/mlnx-sf
@@ -109,6 +109,8 @@ class SF:
         info = self.info["port"]
 
         for pci_dev_index in info:
+            if (not "sfnum" in info[pci_dev_index]):
+                continue
             info[pci_dev_index]["device"] = pci_dev_index.split('/')[1]
             info[pci_dev_index]["sfindex"] = pci_dev_index
             info[pci_dev_index]["aux_dev"] = lookup_aux_dev(info[pci_dev_index]["device"], info[pci_dev_index]["sfnum"])
@@ -128,6 +130,8 @@ class SF:
         else:
             result['output'] = ""
             for pci_dev_index in info:
+                if (not "sfnum" in info[pci_dev_index]):
+                    continue
                 result['output'] += "\n"
                 result['output'] += "SF Index: " + pci_dev_index + "\n"
                 result['output'] += "  Parent PCI dev: " + info[pci_dev_index]["device"] + "\n"


### PR DESCRIPTION
Due to alignments of mlxdevm with upstream devlink, the output of $ mlxdevm port show now contains PFs as well as SFs. In order to avoid a crash, validate that "sfnum" attribute is present in the dictionary before printing SF's related data.

Issue: 4499738