### PR TITLE
tsbin/mlnx_bf_configure: Stop OVS service before changing eswitch mode

### DIFF
--- a/tsbin/mlnx_bf_configure
+++ b/tsbin/mlnx_bf_configure
@@ -136,6 +136,68 @@ get_eswitch_mode()
 	devlink dev eswitch show pci/${pci_dev} 2> /dev/null | cut -d ' ' -f 3
 }
 
+detect_ovs_service()
+{
+	if [ -e /etc/init.d/openvswitch-switch ]; then
+		echo "openvswitch-switch.service"
+	elif [ -e /usr/lib/systemd/system/openvswitch.service ]; then
+		echo "openvswitch.service"
+	else
+		systemctl list-unit-files 2> /dev/null | grep -E "openvswitch.service|openvswitch-switch.service" | awk '{print $1}'
+	fi
+}
+
+stop_ovs_service_with_config_backup()
+{
+	# Backup OVS database if it exists
+	if [ -f /var/lib/openvswitch/conf.db ]; then
+		ovsdb-tool backup /var/lib/openvswitch/conf.db "$ovs_backup_file"
+		if [ $? -ne 0 ]; then
+			error "WARNING: Failed to create OVS database backup"
+		fi
+	fi
+
+	# Delete all OVS bridges
+	for br in $(ovs-vsctl list-br 2>/dev/null); do
+		ovs-vsctl del-br "$br" 2>/dev/null
+	done
+	sleep 2
+
+	# Stop OVS service
+	systemctl stop "$ovs_service"
+	if systemctl is-active --quiet "$ovs_service"; then
+		error "ERROR: Failed to stop $ovs_service"
+	fi
+}
+
+restart_ovs_service_with_old_config()
+{
+	# Restore OVS database from backup if it exists
+	if [ -f "$ovs_backup_file" ]; then
+		systemctl stop "$ovs_service" 2>/dev/null  # Ensure service is stopped
+		cp "$ovs_backup_file" /var/lib/openvswitch/conf.db
+		if [ $? -ne 0 ]; then
+			error "WARNING: Failed to restore OVS database from backup"
+		fi
+	fi
+
+	# Start OVS service - this will restore all bridges from database
+	systemctl start "$ovs_service"
+	sleep 3
+
+	systemctl is-active --quiet "$ovs_service"
+	if [ $? -eq 0 ]; then
+		if [ -f "$ovs_backup_file" ]; then
+			rm -f "$ovs_backup_file"
+		fi
+	else
+		error "WARNING: Failed to restart $ovs_service"
+		if [ -f "$ovs_backup_file" ]; then
+			info "Backup file preserved at $ovs_backup_file for manual recovery"
+		fi
+	fi
+}
+
 set_eswitch_mode()
 {
 	pci_dev=$1
@@ -156,6 +218,17 @@ set_eswitch_mode()
 		error "Failed to stop strongswan.service"
 	else
 		info "Stopped strongswan.service successfully"
+	fi
+
+	# If OVS service is detected, stop it temporarily (to allow eswitch mode change) with backup of the config database
+	ovs_service=`detect_ovs_service`
+	ovs_active=0
+	if [ -n "$ovs_service" ]; then
+		if (systemctl is-active --quiet "$ovs_service" 2>/dev/null); then
+			ovs_active=1
+			ovs_backup_file="/tmp/ovsdb-backup-eswitch-$$.db"
+			stop_ovs_service_with_config_backup
+		fi
 	fi
 
 	rc=1
@@ -184,6 +257,11 @@ set_eswitch_mode()
 	# Start strongSwan again if it was active
 	if [ "$strongswan_active" -eq "0" ]; then
 		systemctl start strongswan.service
+	fi
+
+	# Restart OVS service if it was active before changing the eswitch mode with the old config
+	if [ "$ovs_active" -eq 1 ]; then
+		restart_ovs_service_with_old_config
 	fi
 
 	return $rc


### PR DESCRIPTION
OVS creates and manages internal bridges and ports which can interfere with changing the eswitch mode. Therefore, we need to stop the OVS service (openvswitch-switch) before changing the eswitch mode to ensure a clean transition, and then start it again after changing the eswitch mode if it was active prior to the mode change.

Issue: 4409382