### PR TITLE
Make package python3-only

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -9,10 +9,3 @@ pname:=mlnx-tools
 
 %:
 	dh $@ --with python3
-
-override_dh_auto_install:
-	dh_auto_install
-	sed -i -e '1s/python\>/python3/' \
-		debian/mlnx-tools/usr/sbin/* \
-		debian/mlnx-tools/usr/bin/* \
-		debian/mlnx-tools/usr/share/mlnx-tools/python/*.py

--- a/mlnx-tools.spec
+++ b/mlnx-tools.spec
@@ -40,11 +40,6 @@ Obsoletes: mlnx-ofa_kernel < 5.4, mlnx_en-utils < 5.4
 %description
 Mellanox userland tools and scripts
 
-%global RHEL8 0%{?rhel} >= 8
-%global FEDORA3X 0%{?fedora} >= 30
-%global SLES15 0%{?suse_version} >= 1500
-%global OPENEULER 0%{?openEuler} >= 2
-%global PYTHON3 %{RHEL8} || %{FEDORA3X} || %{SLES15} || %{OPENEULER}
 %global python_dir %{_datadir}/%{name}/python
 
 %prep
@@ -70,10 +65,6 @@ EOF
 touch mlnx-tools-files
 export PKG_VERSION="%{version}"
 %make_install
-%if %PYTHON3
-sed -i -e '1s/python\>/python3/' %{buildroot}/usr/{s,}bin/* \
-	%{buildroot}%{python_dir}/*.py
-%endif
 
 %if "%{_prefix}" != "/usr"
 	conf_env=/etc/profile.d/mlnx-tools.sh

--- a/python/Python/dcbnetlink.py
+++ b/python/Python/dcbnetlink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Copyright (c) 2017 Mellanox Technologies. All rights reserved.
 #

--- a/python/ib2ib_setup
+++ b/python/ib2ib_setup
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2017 Mellanox Technologies. All rights reserved.
 #

--- a/python/mlnx_dump_parser
+++ b/python/mlnx_dump_parser
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/python/mlnx_perf
+++ b/python/mlnx_perf
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Copyright (c) 2017 Mellanox Technologies. All rights reserved.
 #

--- a/python/mlnx_qos
+++ b/python/mlnx_qos
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Copyright (c) 2017 Mellanox Technologies. All rights reserved.
 #

--- a/python/mlnx_tune
+++ b/python/mlnx_tune
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2017 Mellanox Technologies. All rights reserved.
 #

--- a/python/mlx_fs_dump
+++ b/python/mlx_fs_dump
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Copyright (c) 2017 Mellanox Technologies. All rights reserved.
 #

--- a/python/tc_wrap.py
+++ b/python/tc_wrap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Copyright (c) 2017 Mellanox Technologies. All rights reserved.
 #


### PR DESCRIPTION
Package made python scripts python2 by default and converted them in "some cases" to python3. Just default to python3.