### PR TITLE
tsbin/mlnx-sf: Add missing roce field check

### DIFF
--- a/tsbin/mlnx-sf
+++ b/tsbin/mlnx-sf
@@ -127,6 +127,8 @@ class SF:
                 info[pci_dev_index]["function"] = {}
             if "trust" not in info[pci_dev_index]["function"]:
                 info[pci_dev_index]["function"]["trust"] = "NA"
+            if "roce" not in info[pci_dev_index]["function"]:
+                info[pci_dev_index]["function"]["roce"] = "NA"
             if "eswitch" not in info[pci_dev_index]["function"]:
                 info[pci_dev_index]["function"]["eswitch"] = "NA"
 


### PR DESCRIPTION
Add a check for the roce field in the function dictionary to handle cases where the upstream devlink command does not provide this field in its JSON output, unlike the mlxdevm command it replaced.

Ensure the roce field defaults to "NA" when not present, matching the existing behavior for trust and eswitch fields.

Fix KeyError exception when running 'mlnx-sf -a show' with upstream devlink interface.

Fixes: 456712afd67e ("tsbin/mlnx-sf: Support upstream interface for SF")