### PR TITLE
Remove use of 'cap' for SF device creation

### DIFF
--- a/tsbin/mlnx-sf
+++ b/tsbin/mlnx-sf
@@ -201,13 +201,13 @@ class SF:
                 return result
 
         if self.disable_roce:
-            cmd = MLXDEVM + " port function cap set {} roce false".format(self.sfindex)
+            cmd = MLXDEVM + " port function set {} roce false".format(self.sfindex)
             result['status'], result['output'] = get_status_output(cmd, self.verbose)
             if result['status']:
                 return result
 
         if self.enable_eswitch:
-            cmd = MLXDEVM + " port function cap set {idx} eswitch true".format(idx=self.sfindex)
+            cmd = MLXDEVM + " port function set {idx} eswitch true".format(idx=self.sfindex)
             result['status'], result['output'] = get_status_output(cmd, self.verbose)
             if result['status']:
                 return result


### PR DESCRIPTION
Starting with DOCA 3.2.0 the 'cap' argument is no longer supported by the 'mlxdevm' functionality.

This change removes it.

Issue: 4765027