### PR TITLE
tsbin/mlnx_bf_configure: fix typo of local var in ovs_config_doca

### DIFF
--- a/tsbin/mlnx_bf_configure
+++ b/tsbin/mlnx_bf_configure
@@ -628,7 +628,7 @@ ovs_config_doca()
 		return 0
 	fi
 
-	if [ "$doca_intialized" == "true" ]; then
+	if [ "$doca_initialized" == "true" ]; then
 		return 0
 	fi
 


### PR DESCRIPTION
I noticed a typo in local variable `doca_initialized` spelled as `doca_intialized` when checked in a following if statement,