### PR TITLE
mlnx_perf: Fix invalid escape sequence warnings in Python 3.12

### DIFF
--- a/python/mlnx_perf
+++ b/python/mlnx_perf
@@ -92,7 +92,7 @@ keys = []
 prev = get_stats(options.intf, keys)
 
 for key in keys:
-	m = re.match("tx(\d+)_bytes", key)
+	m = re.match(r"tx(\d+)_bytes", key)
 	if m:
 		ring = int(m.groups()[0])
 
@@ -135,13 +135,13 @@ while count != 0:
 				print(("%30s: %s" % (key, thous(bw))))
 				something_printed = True
 
-			m = re.match("tx_prio_?(\d+)_bytes", key)
+			m = re.match(r"tx_prio_?(\d+)_bytes", key)
 			if m:
 				up = int(m.groups()[0])
 				up_bw[up] += bw
 				total_bw += bw
 
-			m = re.match("tx_prio_?(\d+)_packets", key)
+			m = re.match(r"tx_prio_?(\d+)_packets", key)
 			if m:
 				up = int(m.groups()[0])
 				up_packets[up] += bw

--- a/python/mlnx_tune
+++ b/python/mlnx_tune
@@ -370,13 +370,15 @@ class Devices:
 	ConnectX7			= DeviceType("4129", "ConnectX-7")
 	ConnectX8			= DeviceType("4131", "ConnectX-8")
 	ConnectX9			= DeviceType("4133", "ConnectX-9")
+	ConnectX10			= DeviceType("4135", "ConnectX-10")
 	BlueField			= DeviceType("41682", "BlueField")
 	BlueField2			= DeviceType("41686", "BlueField2")
 	BlueField3			= DeviceType("41692", "BlueField3")
+	BlueField4			= DeviceType("41695", "BlueField4")
 	UNDEFINED			= DeviceType(NA, NA)
 	MLX4_CONSUMERS			= [ConnectX2, ConnectX3, ConnectX3Pro, ConnectX3VF, ConnectX3ProVF]
 	MLX5_CONSUMERS			= [
-						BlueField3, BlueField2, BlueField, ConnectX9, ConnectX8, ConnectX7, ConnectX6, ConnectX5,
+						BlueField4, BlueField3, BlueField2, BlueField, ConnectX10, ConnectX9, ConnectX8, ConnectX7, ConnectX6, ConnectX5,
 						ConnectX5EX, ConnectX4, ConnectX4LX, ConnectIB, ConnectX6VF, ConnectX6DX, ConnectX6LX,
 						ConnectX5VF, ConnectX5EXVF, ConnectX4VF,
 						ConnectX4LXVF, ConnectIBVF


### PR DESCRIPTION
Starting in Python 3.12, invalid escape sequences in standard strings
(like '\d') trigger a SyntaxWarning and will eventually become a
SyntaxError in future versions.

This commit fixes the warnings in `mlnx_perf` by converting the regular
expression patterns to raw strings (using the `r` prefix).