### PR TITLE
mlnx_bf_configure: Track OVS_DOCA state to avoid unintended cleanup.

### DIFF
--- a/tsbin/mlnx_bf_configure
+++ b/tsbin/mlnx_bf_configure
@@ -604,6 +604,10 @@ HUGEPAGES_TOOL=/usr/sbin/doca-hugepages
 OVS_DEFAULT_HUGEPAGE_SIZE=2048
 OVS_DEFAULT_HUGEPAGE_NUM=512
 OVS_DEFAULT_HUGEPAGE_NUM_BF4=2048
+# Marker file to track if OVS_DOCA was previously set to "yes".
+# Used to distinguish between OVS_DOCA=no as a default vs. a user
+# explicitly switching from yes to no, so we only run cleanup in the latter case.
+OVS_DOCA_MARKER=/etc/mellanox/.ovs_doca_configured
 
 is_bf4()
 {
@@ -620,6 +624,7 @@ add_default_hugepages_configurations()
 	if [ "X${OVS_DOCA}" != "Xyes" ]; then
 		return
 	fi
+	touch $OVS_DOCA_MARKER
 	[ -z "$OVS_HUGEPAGE_SIZE" ] && OVS_HUGEPAGE_SIZE=$OVS_DEFAULT_HUGEPAGE_SIZE
 	if [ -z "$OVS_HUGEPAGE_NUM" ]; then
 		if is_bf4; then
@@ -642,10 +647,11 @@ config_hugepages()
 
 cleanup_hugepages()
 {
-	if [ "X${OVS_DOCA}" != "Xyes" ] && $HUGEPAGES_TOOL show | grep -q "ovs-doca"; then
+	if [ "X${OVS_DOCA}" != "Xyes" ] && [ -f $OVS_DOCA_MARKER ] && $HUGEPAGES_TOOL show | grep -q "ovs-doca"; then
 		info "Removing ovs-doca default hugepages configuration"
 		$HUGEPAGES_TOOL remove ovs-doca
 		$HUGEPAGES_TOOL reload
+		rm -f $OVS_DOCA_MARKER
 	fi
 }
 
@@ -839,7 +845,10 @@ ovs_config_doca()
 	local doca_initialized=`$vsctl get Open_vSwitch . doca_initialized`
 
 	if [ "X${OVS_DOCA}" != "Xyes" ]; then
-		ovs_cleanup_doca
+		if [ -f $OVS_DOCA_MARKER ]; then
+			ovs_cleanup_doca
+			rm -f $OVS_DOCA_MARKER
+		fi
 		return 0
 	fi
 


### PR DESCRIPTION
Use a marker file (/etc/mellanox/.ovs_doca_configured) to distinguish between OVS_DOCA=no as a default vs a user explicitly switching from yes to no. Only run DOCA cleanup when the marker exists, preventing cleanup of manually configured DOCA setups.