### PR TITLE
tsbin/mlnx_bf_configure: parallelize switchdev transitions across PFs

### DIFF
--- a/tsbin/mlnx_bf_configure
+++ b/tsbin/mlnx_bf_configure
@@ -298,6 +298,30 @@ pci_function_digit_value()
 	esac
 }
 
+# Parallelizing legacy -> switchdev mode requires kernel version >= 6.17
+# due to global devlink locks being removed. Validate support of this
+# functionality by querying kernel version.
+supports_parallel_switchdev()
+{
+	local kver major minor
+
+	kver=$(uname -r)
+	major=${kver%%.*}
+	minor=${kver#*.}
+	minor=${minor%%[!0-9]*}
+
+	if [ -z "$major" ] || [ -z "$minor" ]; then
+		return 1
+	fi
+	if [ "$major" -gt 6 ]; then
+		return 0
+	fi
+	if [ "$major" -eq 6 ] && [ "$minor" -ge 17 ]; then
+		return 0
+	fi
+	return 1
+}
+
 is_dev_eth()
 {
 	dev=$1
@@ -655,25 +679,36 @@ if (is_smartnic_mode "$ctrl_dev"); then
 		fi
 	done
 
-	# Phase 2 (parallel): switchdev transition + ct_max_offloaded_conns per candidate.
-	# This is the dominant cost of the original sequential loop; running it in
-	# parallel removes the per-device serialization.
+	# Phase 2: switchdev transition + ct_max_offloaded_conns per candidate.
+	# This is the dominant cost of the original sequential loop. On kernel 6.17
+	# and later it is run in parallel to remove the per-device serialization;
+	# on older kernels it stays sequential.
 	if [ "${#TO_SWITCHDEV_DEVS[@]}" -gt 0 ]; then
-		info "Switching ${#TO_SWITCHDEV_DEVS[@]} device(s) to switchdev mode in parallel: ${TO_SWITCHDEV_DEVS[*]}"
-		SWITCHDEV_PIDS=()
-		for dev in "${TO_SWITCHDEV_DEVS[@]}"; do
-			(
+		if (supports_parallel_switchdev); then
+			info "Switching ${#TO_SWITCHDEV_DEVS[@]} device(s) to switchdev mode in parallel: ${TO_SWITCHDEV_DEVS[*]}"
+			SWITCHDEV_PIDS=()
+			for dev in "${TO_SWITCHDEV_DEVS[@]}"; do
+				(
+					set_eswitch_mode ${dev} switchdev
+					rc=$?
+					set_dev_param ${dev} ct_max_offloaded_conns ${CT_MAX_OFFLOADED_CONNS}
+					exit $rc
+				) &
+				SWITCHDEV_PIDS+=( $! )
+			done
+			for pid in "${SWITCHDEV_PIDS[@]}"; do
+				wait "$pid"
+				RC=$((RC+$?))
+			done
+		else
+	# Fallback path for kernels without parallelized switchdev support
+			for dev in "${TO_SWITCHDEV_DEVS[@]}"; do
 				set_eswitch_mode ${dev} switchdev
-				rc=$?
+				RC=$((RC+$?))
+
 				set_dev_param ${dev} ct_max_offloaded_conns ${CT_MAX_OFFLOADED_CONNS}
-				exit $rc
-			) &
-			SWITCHDEV_PIDS+=( $! )
-		done
-		for pid in "${SWITCHDEV_PIDS[@]}"; do
-			wait "$pid"
-			RC=$((RC+$?))
-		done
+			done
+		fi
 	fi
 
 	# Phase 3 (sequential): post-transition per-device state (counters, lists,

--- a/tsbin/mlnx_bf_configure
+++ b/tsbin/mlnx_bf_configure
@@ -310,7 +310,9 @@ supports_parallel_switchdev()
 	minor=${kver#*.}
 	minor=${minor%%[!0-9]*}
 
-	if [ -z "$major" ] || [ -z "$minor" ]; then
+	# Anything we cannot parse as <major>.<minor> falls back to the
+	# sequential path.
+	if ! [[ "$major" =~ ^[0-9]+$ ]] || ! [[ "$minor" =~ ^[0-9]+$ ]]; then
 		return 1
 	fi
 	if [ "$major" -gt 6 ]; then
@@ -319,6 +321,40 @@ supports_parallel_switchdev()
 	if [ "$major" -eq 6 ] && [ "$minor" -ge 17 ]; then
 		return 0
 	fi
+	return 1
+}
+
+# Decide whether the legacy -> switchdev transitions run in parallel.
+# Controlled by PARALLEL_SWITCHDEV_ENABLE (default "yes"), case insensitive:
+#   yes|1   - parallelize only if the kernel supports it (default)
+#   no|0    - always serialize, even on a supported kernel
+#   force   - always parallelize, even if the kernel looks unsupported
+# Unrecognized values are treated as the default.
+parallel_switchdev_enabled()
+{
+	local mode=`echo "${PARALLEL_SWITCHDEV_ENABLE}" | tr '[:lower:]' '[:upper:]'`
+
+	case "${mode}" in
+		FORCE)
+			info "PARALLEL_SWITCHDEV_ENABLE=${mode}: parallelizing switchdev transitions regardless of kernel $(uname -r)"
+			return 0
+			;;
+		NO|0)
+			info "PARALLEL_SWITCHDEV_ENABLE=${mode}: switchdev transitions will run sequentially"
+			return 1
+			;;
+		YES|1)
+			;;
+		*)
+			error "Unrecognized PARALLEL_SWITCHDEV_ENABLE value '${mode}'. Falling back to kernel version detection."
+			;;
+	esac
+
+	if (supports_parallel_switchdev); then
+		return 0
+	fi
+
+	info "Kernel $(uname -r) predates 6.17: switchdev transitions will run sequentially"
 	return 1
 }
 
@@ -541,6 +577,7 @@ if [ -z "${ENABLE_ESWITCH_MULTIPORT}" ]; then
 		ENABLE_ESWITCH_MULTIPORT="no"
 	fi
 fi
+PARALLEL_SWITCHDEV_ENABLE=${PARALLEL_SWITCHDEV_ENABLE:-"yes"}
 MLXCONFIG_DEBUG_LOG=${MLXCONFIG_DEBUG_LOG:-"/tmp/mlxconfig_debug.log"}
 LOG_LEVEL=${LOG_LEVEL:-"info"}
 SWITCHDEV_DEVICES_LIST=()
@@ -680,11 +717,12 @@ if (is_smartnic_mode "$ctrl_dev"); then
 	done
 
 	# Phase 2: switchdev transition + ct_max_offloaded_conns per candidate.
-	# This is the dominant cost of the original sequential loop. On kernel 6.17
-	# and later it is run in parallel to remove the per-device serialization;
-	# on older kernels it stays sequential.
+	# This is the dominant cost of the original sequential loop. It is run in
+	# parallel to remove the per-device serialization when
+	# parallel_switchdev_enabled says so (PARALLEL_SWITCHDEV_ENABLE plus kernel
+	# version); otherwise it stays sequential.
 	if [ "${#TO_SWITCHDEV_DEVS[@]}" -gt 0 ]; then
-		if (supports_parallel_switchdev); then
+		if (parallel_switchdev_enabled); then
 			info "Switching ${#TO_SWITCHDEV_DEVS[@]} device(s) to switchdev mode in parallel: ${TO_SWITCHDEV_DEVS[*]}"
 			SWITCHDEV_PIDS=()
 			for dev in "${TO_SWITCHDEV_DEVS[@]}"; do
@@ -701,7 +739,7 @@ if (is_smartnic_mode "$ctrl_dev"); then
 				RC=$((RC+$?))
 			done
 		else
-	# Fallback path for kernels without parallelized switchdev support
+			# Fallback path when parallel switchdev is unsupported or disabled
 			for dev in "${TO_SWITCHDEV_DEVS[@]}"; do
 				set_eswitch_mode ${dev} switchdev
 				RC=$((RC+$?))

--- a/tsbin/mlnx_bf_configure
+++ b/tsbin/mlnx_bf_configure
@@ -332,7 +332,7 @@ supports_parallel_switchdev()
 # Unrecognized values are treated as the default.
 parallel_switchdev_enabled()
 {
-	local mode=`echo "${PARALLEL_SWITCHDEV_ENABLE}" | tr '[:lower:]' '[:upper:]'`
+	local mode="${PARALLEL_SWITCHDEV_ENABLE^^}"
 
 	case "${mode}" in
 		FORCE)
@@ -721,6 +721,7 @@ if (is_smartnic_mode "$ctrl_dev"); then
 	# parallel to remove the per-device serialization when
 	# parallel_switchdev_enabled says so (PARALLEL_SWITCHDEV_ENABLE plus kernel
 	# version); otherwise it stays sequential.
+
 	if [ "${#TO_SWITCHDEV_DEVS[@]}" -gt 0 ]; then
 		if (parallel_switchdev_enabled); then
 			info "Switching ${#TO_SWITCHDEV_DEVS[@]} device(s) to switchdev mode in parallel: ${TO_SWITCHDEV_DEVS[*]}"

--- a/tsbin/mlnx_bf_configure
+++ b/tsbin/mlnx_bf_configure
@@ -571,6 +571,11 @@ declare -A CX9_DEV_LAST_ECPF  # key=PCI domain:bus (physical CX-9), value=last E
 # Set eswitch mode to switchdev for all devices
 if (is_smartnic_mode "$ctrl_dev"); then
 	stop_ipsec_services
+
+	# Phase 1 (sequential): pre-transition per-device setup; collect candidates
+	# for the parallel switchdev transition in Phase 2.
+	ELIGIBLE_DEVS=()
+	TO_SWITCHDEV_DEVS=()
 	# Rank each BDF by PCI device ID before sorting (0=NIC, 1=BlueField)
 	# so all NIC (e.g. ASTRA CX-9) links are configured before the
 	# BlueField devices. Within each group the order is unchanged:
@@ -589,6 +594,7 @@ if (is_smartnic_mode "$ctrl_dev"); then
 			info "Link type is IB for ${dev}. Skipping mode configuration."
 			continue
 		fi
+		ELIGIBLE_DEVS+=( "$dev" )
 
 		if [ "X${LAG_HASH_MODE}" == "Xno" ]; then
 			set_dev_param ${dev} lag_port_select_mode queue_affinity
@@ -645,12 +651,34 @@ if (is_smartnic_mode "$ctrl_dev"); then
 			if [ "X${LEGACY_METADATA_MATCH_MODE}" == "Xyes" ]; then
 				set_dev_param ${dev} vport_match_mode legacy
 			fi
-
-			set_eswitch_mode ${dev} switchdev
-			RC=$((RC+$?))
-
-			set_dev_param ${dev} ct_max_offloaded_conns ${CT_MAX_OFFLOADED_CONNS}
+			TO_SWITCHDEV_DEVS+=( "$dev" )
 		fi
+	done
+
+	# Phase 2 (parallel): switchdev transition + ct_max_offloaded_conns per candidate.
+	# This is the dominant cost of the original sequential loop; running it in
+	# parallel removes the per-device serialization.
+	if [ "${#TO_SWITCHDEV_DEVS[@]}" -gt 0 ]; then
+		info "Switching ${#TO_SWITCHDEV_DEVS[@]} device(s) to switchdev mode in parallel: ${TO_SWITCHDEV_DEVS[*]}"
+		SWITCHDEV_PIDS=()
+		for dev in "${TO_SWITCHDEV_DEVS[@]}"; do
+			(
+				set_eswitch_mode ${dev} switchdev
+				rc=$?
+				set_dev_param ${dev} ct_max_offloaded_conns ${CT_MAX_OFFLOADED_CONNS}
+				exit $rc
+			) &
+			SWITCHDEV_PIDS+=( $! )
+		done
+		for pid in "${SWITCHDEV_PIDS[@]}"; do
+			wait "$pid"
+			RC=$((RC+$?))
+		done
+	fi
+
+	# Phase 3 (sequential): post-transition per-device state (counters, lists,
+	# esw_multiport_device). Kept sequential because it mutates shared shell arrays.
+	for dev in "${ELIGIBLE_DEVS[@]}"; do
 		eswitch_mode=`get_eswitch_mode ${dev}`
 		if [ "${eswitch_mode}" == "switchdev" ]; then
 			num_of_devs_switchdev=$((num_of_devs_switchdev+1))


### PR DESCRIPTION
The per-device loop performs the LEGACY -> switchdev (OFFLOADS) eswitch mode transition serially, which is the dominant cost of openibd boot time on systems with many mlx5 PFs. Each transition takes ~3-4 s of kernel work; on a system with 32 PFs this is ~115 s of serial wall-clock.

Split the loop into three phases:
  1. Sequential pre-transition setup (lag_port_select_mode, encap, steering_mode, IPsec full-offload) and candidate collection. Devices that need a switchdev transition are appended to TO_SWITCHDEV_DEVS; eligible devices are appended to ELIGIBLE_DEVS for the post-pass.
  2. Parallel switchdev transition: for each candidate, spawn a subshell that runs 'set_eswitch_mode $dev switchdev' followed by 'set_dev_param $dev ct_max_offloaded_conns ...'. The subshell exits with set_eswitch_mode's status, which is propagated to RC via wait, preserving the original per-device failure accounting.
  3. Sequential post-transition bookkeeping: increment num_of_devs_switchdev, append to SWITCHDEV_DEVICES_LIST / SD_DEVICES_LIST / DEVICE_LIST_FOR_OVS_BRIDGES, and set esw_multiport_device. Stays sequential because subshell array writes do not propagate to the parent.

The post-loop esw_multiport block (cd67a5a) is unchanged and continues to run once after Phase 3 on the last device that entered switchdev mode.

OpenIBD start up (driver load + switchdev enablement): 3 min 28.408s -> 37.316s