### PR TITLE
mlnx_bf_configure: Fix steering mode check for SmartNIC mode

### DIFF
--- a/tsbin/mlnx_bf_configure
+++ b/tsbin/mlnx_bf_configure
@@ -599,7 +599,7 @@ if (is_smartnic_mode "$ctrl_dev"); then
 					RC=$((RC+$?))
 				fi
 				steering_mode=`get_steering_mode ${dev}`
-				if [ "${steering_mode}" == "smfs" ]; then
+				if [ "${steering_mode}" != "dmfs" ]; then
 					set_steering_mode ${dev} dmfs
 				fi
 			else


### PR DESCRIPTION
When IPSEC_FULL_OFFLOAD="yes", switch to dmfs whenever the current mode is not dmfs, rather than only when it is smfs. The default steering mode on BF4 is hmfs, not smfs, so the previous check missed it.

Issue: 5133798