### PR TITLE
udev: Align BF4 representor and SF naming with mlnx-ofa_kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,4 @@ install:
 	$(INSTALL) -m 0755 $(PYTHON_SBIN) -t $(DESTDIR)$(SBIN_DIR)/
 	$(INSTALL) -m 0755 $(PYTHON_BIN) -t $(DESTDIR)$(BIN_DIR)/
 	mkdir -p $(DESTDIR)/etc/mellanox/hugepages.d/
+	$(INSTALL) -m 0644 udev/astra_cards_location_map.json -t $(DESTDIR)$(SYSCONFDIR)/mellanox/

--- a/mlnx-tools.spec
+++ b/mlnx-tools.spec
@@ -93,6 +93,7 @@ sed -i -e '1s/python\>/python3/' %{buildroot}/usr/{s,}bin/* \
 	echo $conf_env >> mlnx-tools-files
 %endif
 install -d %{buildroot}/etc/mellanox/hugepages.d
+install -m 0644 udev/astra_cards_location_map.json %{buildroot}/etc/mellanox/
 
 %clean
 rm -rf %{buildroot}
@@ -119,6 +120,7 @@ rm -rf %{buildroot}
 %{python_dir}/netlink.py*
 %exclude %{python_dir}/__pycache__/*.pyc
 /etc/mellanox/hugepages.d
+/etc/mellanox/astra_cards_location_map.json
 
 %changelog
 * Wed May 12 2021 Tzafrir Cohen <nvidia@cohens.org.il> - 5.2.0-1

--- a/udev/astra_cards_location_map.json
+++ b/udev/astra_cards_location_map.json
@@ -1,0 +1,42 @@
+{
+  "0004:03:00.0": {
+    "Redfish_label": "CX_0",
+    "GA": 0,
+    "Redfish_PartLocationContext": "Chassis_0/Bay-B-Left-Bottom"
+  },
+  "0004:06:00.0": {
+    "Redfish_label": "CX_1",
+    "GA": 1,
+    "Redfish_PartLocationContext": "Chassis_0/Bay-B-Left-Bottom"
+  },
+  "0005:03:00.0": {
+    "Redfish_label": "CX_2",
+    "GA": 0,
+    "Redfish_PartLocationContext": "Chassis_0/Bay-B-Left-Top"
+  },
+  "0005:06:00.0": {
+    "Redfish_label": "CX_3",
+    "GA": 1,
+    "Redfish_PartLocationContext": "Chassis_0/Bay-B-Left-Top"
+  },
+  "0000:03:00.0": {
+    "Redfish_label": "CX_4",
+    "GA": 0,
+    "Redfish_PartLocationContext": "Chassis_0/Bay-B-Right-Bottom"
+  },
+  "0000:06:00.0": {
+    "Redfish_label": "CX_5",
+    "GA": 1,
+    "Redfish_PartLocationContext": "Chassis_0/Bay-B-Right-Bottom"
+  },
+  "0001:03:00.0": {
+    "Redfish_label": "CX_6",
+    "GA": 0,
+    "Redfish_PartLocationContext": "Chassis_0/Bay-B-Right-Top"
+  },
+  "0001:06:00.0": {
+    "Redfish_label": "CX_7",
+    "GA": 1,
+    "Redfish_PartLocationContext": "Chassis_0/Bay-B-Right-Top"
+  }
+}

--- a/udev/rules.d/82-net-setup-link.rules
+++ b/udev/rules.d/82-net-setup-link.rules
@@ -1,12 +1,17 @@
 SUBSYSTEM=="net", NAME=="side-*-eth[0-9]*", GOTO="net_setup_skip_link_name"
 
-SUBSYSTEM=="net", ACTION=="add", ATTR{phys_switch_id}!="", ATTR{phys_port_name}!="", ATTR{phys_port_name}!="*pf*sf*" \
+SUBSYSTEM=="net", ACTION=="add", ATTR{phys_switch_id}!="", ATTR{phys_port_name}!="", ATTR{phys_port_name}!="*pf*sf*", ENV{ID_MODEL_ID}!="0x10*" \
         IMPORT{program}="/lib/udev/vf-net-link-name.sh $name $attr{phys_port_name} $attr{phys_switch_id} $attr{ifindex}" \
         NAME="$env{NAME}", RUN+="/lib/udev/mlnx_bf_udev $env{NAME}", GOTO="net_setup_skip_link_name"
 
 
-SUBSYSTEM=="net", ACTION=="add", ATTR{phys_port_name}!="", ATTR{phys_port_name}!="*pf*sf*" \
+SUBSYSTEM=="net", ACTION=="add", ATTR{phys_port_name}!="", ATTR{phys_port_name}!="*pf*sf*", ENV{ID_MODEL_ID}!="0x10*" \
         IMPORT{program}="/lib/udev/vf-net-link-name.sh $name $attr{phys_port_name}" \
-        NAME="$env{NAME}", RUN+="/lib/udev/mlnx_bf_udev $env{NAME}"
+        NAME="$env{NAME}", RUN+="/lib/udev/mlnx_bf_udev $env{NAME}", GOTO="net_setup_skip_link_name"
+
+SUBSYSTEM=="net", ACTION=="add", ENV{ID_MODEL_ID}=="0x101e" \
+	IMPORT{program}="/lib/udev/vf-net-link-name.sh $name $attr{phys_port_name} $attr{phys_switch_id} $attr{ifindex}" \
+	NAME="$env{NAME}", RUN+="/lib/udev/mlnx_bf_udev $env{NAME}"
+
 
 LABEL="net_setup_skip_link_name"

--- a/udev/rules.d/84-BF4-representors-naming.rules
+++ b/udev/rules.d/84-BF4-representors-naming.rules
@@ -1,0 +1,64 @@
+# /lib/udev/rules.d/84-BF4-representors-naming.rules
+# Mellanox Technologies BF4 Family integrated network controller [BlueField-4 integrated network controller] [15b3:a2df]
+
+# SF representors with controller number (PCI bus, switchdev)
+# B${domain}${bus}c4${phys_port_name}
+# e.g.:
+#   SF rep on PF0:  BDF=0006:01:00.0  phys_port_name=pf0sf88  →  B61c4pf0sf88
+#   SF rep on PF1:  BDF=0006:01:00.1  phys_port_name=pf1sf42  →  B61c4pf1sf42
+#
+# Once RM 5056945 is fixed, the workaround for specific PCI BDF of 0006:xx.xx.0 should be removed,
+# because controller number c4 is expected to be returned by the driver.
+SUBSYSTEM=="net", ACTION=="add", TEST=="/etc/mlnx-release", KERNELS=="0006:01:00.0", \
+    ATTRS{vendor}=="0x15b3", ATTRS{device}=="0xa2df", \
+    ATTR{phys_port_name}=="pf0sf*", \
+    NAME:="B61c4$attr{phys_port_name}"
+SUBSYSTEM=="net", ACTION=="add", TEST=="/etc/mlnx-release", KERNELS=="0006:01:00.1", \
+    ATTRS{vendor}=="0x15b3", ATTRS{device}=="0xa2df", \
+    ATTR{phys_port_name}=="pf1sf*", \
+    NAME:="B61c4$attr{phys_port_name}"
+
+# PF, VF, SF representors (anything switchdev on the PCI bus with "pf" in phys_port_name)
+# B${domain}${bus}${phys_port_name}
+# e.g.:
+#   PF host-rep:  BDF=0006:01:00.0  phys_port_name=c1pf0    →  B61c1pf0
+#   VF rep:       BDF=0006:01:00.0  phys_port_name=pf0vf3   →  B61pf0vf3
+#   VF rep:       BDF=0006:01:00.1  phys_port_name=pf1vf12  →  B61pf1vf12
+#   SF rep:       BDF=0002:01:00.0  phys_port_name=pf0sf0   →  B21pf0sf0
+#
+SUBSYSTEM=="net", SUBSYSTEMS=="pci", ACTION=="add", TEST=="/etc/mlnx-release",  \
+    ATTRS{vendor}=="0x15b3", ATTRS{device}=="0xa2df", \
+    DRIVERS!="mlx5_core.sf", \
+    ATTR{phys_switch_id}!="", ATTR{phys_port_name}!="", \
+    ATTR{phys_port_name}=="*pf*", \
+    PROGRAM="/bin/sh -c 'set -- $$(echo $id | tr :. \" \"); printf B%%d%%d 0x$$1 0x$$2'", \
+    NAME="%c$attr{phys_port_name}"
+
+
+# SF netdev (auxiliary bus)
+# enP${domain}p${bus}s${dev}f${func}S${sfnum}
+# e.g.:
+#   SF netdev:  parent PF BDF=0002:01:00.0  sfnum=0   →  enP2p1s0f0S0
+#   SF netdev:  parent PF BDF=0002:01:00.1  sfnum=42  →  enP2p1s0f1S42
+#
+SUBSYSTEM=="net", SUBSYSTEMS=="auxiliary", ACTION=="add", TEST=="/etc/mlnx-release", ATTRS{sfnum}!="", \
+    PROGRAM="/bin/sh -c 'a=$$(readlink -f /sys$devpath/device); set -- $$(basename $$(dirname $$a) | tr :. \" \"); printf enP%%dp%%ds%%df%%dS%%d 0x$$1 0x$$2 0x$$3 0x$$4 $$(cat $$a/sfnum)'", \
+    NAME="%c"
+
+
+# NOTES:
+#
+# PROGRAM="/bin/sh -c 'set -- $$(echo $id | tr :. \" \"); printf B%%d%%d 0x$$1 0x$$2'"
+#                      │              │    │             │              │
+#                      │              │    │             │              └── args "0x$1" "0x$2" → printf parses as hex via "0x" prefix → "0x0006"→6, "0x01"→1
+#                      │              │    │             └───────────────── printf format (%%d → %d after udev unescape) → "B61"
+#                      │              │    └─────────────────────────────── tr replaces both ':' and '.' with spaces in one pass: "0006:01:00.0" → "0006 01 00 0"
+#                      │              └──────────────────────────────────── $id = matched parent's kernel name. SUBSYSTEMS=="pci" anchors the walk on the
+#                      │                                                    PCI device, so $id is the BDF (e.g. "0006:01:00.0")
+#                      └─────────────────────────────────────────────────── set -- consumes BDF tokens into positional parameters: $1=0006 $2=01 $3=00 $4=0
+#
+# NAME:="%c$attr{phys_port_name}"
+#     │  │   │
+#     │  │   └── 'c1pf0' (attribute on the iface itself)
+#     │  └────── 'B61'   (PROGRAM stdout)
+#     └───────── ':='    locks NAME so no later rule can override it, '=' assigns without locking

--- a/udev/rules.d/86-ASTRA-CX9-naming.rules
+++ b/udev/rules.d/86-ASTRA-CX9-naming.rules
@@ -1,0 +1,18 @@
+# /lib/udev/rules.d/86-ASTRA-CX9-naming.rules
+# ASTRA mode: rename ConnectX-9 [15b3:1025] netdevs using card index from JSON.
+#
+# CX-9 uplink netdevs (row 10):
+#   BDF=0004:03:00.0  phys_port_name=p0  → A0p0
+#   BDF=0004:03:00.1  phys_port_name=p1  → A0p1
+#   BDF=0001:06:00.2  phys_port_name=p2  → A7p2
+#
+# The helper /lib/udev/mlnx-astra-rename maps the BDF to "A<card_idx>"
+# by looking up /etc/mellanox/astra_cards_location_map.json.
+
+SUBSYSTEM=="net", SUBSYSTEMS=="pci", ACTION=="add", TEST=="/etc/mlnx-release", \
+    TEST=="/etc/mellanox/astra_cards_location_map.json", \
+    ATTRS{vendor}=="0x15b3", ATTRS{device}=="0x1025", \
+    DRIVERS=="mlx5_core", \
+    ATTR{phys_port_name}!="", ATTR{phys_switch_id}!="", \
+    PROGRAM="/lib/udev/mlnx-astra-rename $id", \
+    NAME:="%c$attr{phys_port_name}"

--- a/udev/scripts/auxdev-sf-netdev-rename
+++ b/udev/scripts/auxdev-sf-netdev-rename
@@ -15,13 +15,6 @@
 SFNUM=$1
 IFINDEX=$2
 
-PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin
-
-is_bf=`lspci -s 00:00.0 2> /dev/null | grep -wq "PCI bridge: Mellanox Technologies" && echo 1 || echo 0`
-if [ $is_bf -ne 1 ]; then
-	exit 0
-fi
-
 for sf_ndev in `ls /sys/class/net/`; do
 	_ifindex=`cat /sys/class/net/$sf_ndev/ifindex | head -1 2>/dev/null`
 	if [ "$_ifindex" = "$IFINDEX" ]

--- a/udev/scripts/sf-rep-netdev-rename
+++ b/udev/scripts/sf-rep-netdev-rename
@@ -3,13 +3,6 @@
 PORT_NAME=$1
 IFINDEX=$2
 
-PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin
-
-is_bf=`lspci -s 00:00.0 2> /dev/null | grep -wq "PCI bridge: Mellanox Technologies" && echo 1 || echo 0`
-if [ $is_bf -ne 1 ]; then
-	exit 0
-fi
-
 for rep_ndev in `ls /sys/class/net/`; do
 	_ifindex=`cat /sys/class/net/$rep_ndev/ifindex | head -1 2>/dev/null`
 	if [ "$_ifindex" = "$IFINDEX" ]

--- a/udev/scripts/vf-net-link-name.sh
+++ b/udev/scripts/vf-net-link-name.sh
@@ -1,25 +1,18 @@
 #!/bin/bash
 
-ORIG_NAME=$1
-SWID=$3
+SWID=$2
 # might be pf0vf1 so only get vf number
-ORIG_PORT=$2
-PORT=${2##*f}
-PORT_NAME=`echo ${2} | sed -e "s/c[[:digit:]]\+//"`
-IFINDEX=$4
+PORT=${1##*f}
+PORT_NAME=`echo ${1} | sed -e "s/c[[:digit:]]\+//"`
+IFINDEX=$3
+ECVF=0
+BLUEFIELD_DEVICES="a2d[26cf]"
 
 # need the PATH for BF ARM lspci to work
-PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin
-
-is_bf=`lspci -s 00:00.0 2> /dev/null | grep -wq "PCI bridge: Mellanox Technologies" && echo 1 || echo 0`
-if [ $is_bf -ne 1 ]; then
-        echo "NAME=$ORIG_NAME"
-	exit 0
-fi
+PATH=/bin:/sbin:/usr/bin:/usr/sbin
 
 if [[ "$ID_NET_DRIVER" != *"mlx5"* ]]; then
-        echo "NAME=$ORIG_NAME"
-        exit 1
+    exit 1
 fi
 
 function get_mh_bf_rep_name() {
@@ -38,7 +31,12 @@ function get_mh_bf_rep_name() {
                         #pdev is : 0000:03:00.0, so extract them by their index
                         f=${parent_pdev: -1}
                         if [[ $PORT_NM == p[0-7] ]]; then
-                                echo "p${f}"
+                                # Use phys_port_name directly — it already
+                                # carries the correct physical port index.
+                                # Using PCI function number fails on BF4 where
+                                # each port lives in a separate PCI domain but
+                                # both use function 0.
+                                echo "$PORT_NM"
                                 return 0
                         fi
 
@@ -55,33 +53,59 @@ function get_mh_bf_rep_name() {
         done
 }
 
+is_bf=`lspci -s 00:00.0 2> /dev/null | grep -wq "PCI bridge: Mellanox Technologies" && echo 1 || echo 0`
+if [ $is_bf -ne 1 ]; then
+	# Check if the device is a Mellanox BlueField 4 or newer
+	if [ -e /etc/mlnx-release ]; then
+		if [ $(lspci -nD -d 15b3: | grep -E "$BLUEFIELD_DEVICES" | wc -l) -gt 0 ]; then
+			is_bf=1
+		fi
+	fi
+fi
+
 if [ $is_bf -eq 1 ]; then
         num_of_pf=`lspci 2> /dev/null | grep -w "network" | wc -l`
         if [ $num_of_pf -gt 2 ]; then
                 echo "NAME=`get_mh_bf_rep_name $PORT_NAME $IFINDEX`"
                 exit 0
         fi
+	if [ $ID_MODEL_ID != "0x101e" ]; then
 
-        echo NAME=`echo ${ORIG_PORT} | sed -e "s/\(pf[[:digit:]]\+\)$/\1hpf/;s/c[[:digit:]]\+//"`
-        exit 0
+		echo NAME=`echo ${1} | sed -e "s/\(pf[[:digit:]]\+\)$/\1hpf/;s/c[[:digit:]]\+//"`
+		exit 0
+	else
+		ECVF=1
+	fi
 fi
 
-# Ditch stdout, use stderr as new stdout:
-if udevadm test-builtin path_id "/sys$DEVPATH" 2>&1 1>/dev/null \
-	| grep -q 'Network interface NamePolicy= disabled'
-then
-	echo "NAME=$INTERFACE"
-	exit 0
+if [ $ECVF -ne 1 ]; then
+	# Ditch use stderr as new stdout:
+	if udevadm test-builtin path_id "/sys$DEVPATH" 2>&1 1>/dev/null \
+		| grep -q 'Network interface NamePolicy= disabled'
+	then
+		echo "NAME=$INTERFACE"
+		exit 0
+	fi
 fi
 
 # for pf and uplink rep fall to slot or path.
-udevversion=`/sbin/udevadm --version`
+udevversion=`udevadm --version`
 skip=0
 if [ "$ID_NET_DRIVER" == "mlx5e_rep" ]; then
     if [ "$udevversion" == "219" ] || [ "$udevversion" == "229" ]; then
         skip=1
     fi
 fi
+
+function test_if_pf() {
+    MODEL_ID=$1
+
+    case "$MODEL_ID" in
+        "0x1011" | "0x1013" | "0x1015" | "0x1017" | "0x1019" | "0x1021" | "0x1023" ) IS_PF="TRUE";;
+        *) IS_PF="FALSE";;
+    esac
+    return 0
+}
 
 if [ "$skip" == "0" ]; then
 	if [ -n "$ID_NET_NAME_SLOT" ]; then
@@ -95,6 +119,31 @@ if [ "$skip" == "0" ]; then
 	    NAME=`echo $NAME | sed 's/np.v/v/'`
 	    echo NAME=$NAME
 	    exit
+	else
+	    IS_PF="UNKNOWN"
+	    if [[ -n "$ID_PATH" && "$ID_NET_DRIVER" == "mlx5_core" ]]; then
+		test_if_pf "$ID_MODEL_ID"
+		if [ "$IS_PF" == "TRUE" ]; then
+		    xpci=`echo $ID_PATH | cut -d "-" -f 2`
+		    HXDM=`echo $xpci | cut -d ":" -f 1`
+		    HXBS=`echo $xpci | cut -d ":" -f 2`
+		    HXSL=`echo $xpci | cut -d ":" -f 3 | cut -d "." -f 1`
+		    HXFN=`echo $xpci | cut -d ":" -f 3 | cut -d "." -f 2`
+		    DCDM=$((16#$HXDM))
+		    DCBS=$((16#$HXBS))
+		    DCSL=$((16#$HXSL))
+		    DCFN=$((16#$HXFN))
+		    if [ "$DCDM" == "0" ]; then
+			NM='enp'"$DCBS"'s'"$DCSL"'f'"$DCFN"
+		    else
+			NM='enP'"$DCDM"'p'"$DCBS"'s'"$DCSL"'f'"$DCFN"
+		    fi
+		    if (( ${#NM} <= 15 )); then
+			echo "NAME=$NM"
+			exit
+		    fi
+		fi
+	    fi
 	fi
 fi
 
@@ -195,6 +244,9 @@ for cnt in {1..2}; do
         parent_path=`get_pci_name $pci ID_NET_NAME_SLOT`
         if [ -z "$parent_path" ]; then
             parent_path=`get_pci_name $pci ID_NET_NAME_PATH`
+            if [ -z "$parent_path" ]; then
+                continue
+            fi
         fi
         echo "NAME=${parent_path}_$PORT"
         exit


### PR DESCRIPTION
Sync interface naming rules and helper scripts to match the consolidated udev rules in mlnx-ofa_kernel (144aea3):

New files:
  udev/rules.d/84-BF4-representors-naming.rules:
    - BF4 representor naming from mlnx-ofa_kernel-4.0
    - SF representors with c4 controller workaround (RM 5056945) for BDF 0006:01:00.x
    - PF/VF/SF representors: B<domain><bus><phys_port_name>
      using inclusion-based filter (phys_port_name=="*pf*")
    - SF netdevs on auxiliary bus: enP<domain>p<bus>s<dev>f<func>S<sfnum>

  udev/rules.d/86-ASTRA-CX9-naming.rules:
    - ASTRA CX-9 [15b3:1025] naming from mlnx-ofa_kernel-4.0
    - Uses mlnx-astra-rename helper to map BDF to card index from /etc/mellanox/astra_cards_location_map.json
    - Naming: A<card_idx><phys_port_name> (e.g. A0p0, A7p2)

  udev/astra_cards_location_map.json:
    - ASTRA CX-9 BDF-to-card-index map from mlnx-ofa_kernel-4.0
    - Installed to /etc/mellanox/astra_cards_location_map.json

Modified:
  udev/rules.d/82-net-setup-link.rules:
    - Add ENV{ID_MODEL_ID}!="0x10*" filter to skip ConnectX devices
    - Add separate rule for EC VF (ID_MODEL_ID==0x101e)
    - Add GOTO to prevent double-matching

  udev/scripts/auxdev-sf-netdev-rename:
    - Remove redundant is_bf check and PATH setup (BF detection now handled by udev rule filtering)

  udev/scripts/sf-rep-netdev-rename:
    - Remove redundant is_bf check and PATH setup (BF detection now handled by udev rule filtering)

  udev/scripts/vf-net-link-name.sh:
    - Change argument order to match mlnx-ofa_kernel-4.0: $1=phys_port_name, $2=phys_switch_id, $3=ifindex (removed $name as first arg, removed ORIG_NAME/ORIG_PORT)
    - Move is_bf detection after get_mh_bf_rep_name() definition
    - Add BF4 device detection fallback via PCI device ID (a2d[26cf]) when standard PCI bridge check fails
    - Fix uplink rep naming: use phys_port_name directly for p[0-7] instead of PCI function number (fails on BF4 dual-domain topology where both ports use function 0)
    - Add ECVF (0x101e) support path
    - Add test_if_pf() with PCI domain-aware naming (enP<D>p<B>s<S>f<F> when domain != 0)
    - Add null parent_path guard in VF rep section
    - Use absolute PATH instead of appending to $PATH
    - Simplify udevadm call (drop /sbin/ prefix)

  Makefile:
    - Install udev/astra_cards_location_map.json to /etc/mellanox/astra_cards_location_map.json

  mlnx-tools.spec:
    - Install and package astra_cards_location_map.json under /etc/mellanox/