### PR TITLE
  mlnx_bf_configure: Create SFs before enabling ESW multiport

### DIFF
--- a/tsbin/mlnx_bf_configure
+++ b/tsbin/mlnx_bf_configure
@@ -842,45 +842,65 @@ create_snap_dma_sf()
 
 	# --- Identify the target ECPF on the 2nd PCI link ---
 	# a. List all switchdev ECPFs (ASTRA/HW multiplane excluded upstream)
-	# b. Find PCI link (domain:bus) of each ECPF
-	# c. Find RDMA device for each ECPF
-	# d. Eliminate ECPFs that have an RDMA device
-	# e. Eliminate ECPFs sharing the same PCI link as RDMA-bearing ECPFs
-	# f. Pick the first remaining ECPF
-	local links_with_rdma=""
-	local dev pci_link rdma_dev
-
-	for dev in ${SWITCHDEV_DEVICES_LIST[@]}; do
-		pci_link=$(echo $dev | cut -d: -f1-2)
-		rdma_dev=$(/bin/ls /sys/bus/pci/devices/${dev}/infiniband/ 2>/dev/null | head -1)
-		if [ -n "$rdma_dev" ]; then
-			links_with_rdma="$links_with_rdma $pci_link"
-			debug "SNAP DMA SF: ECPF $dev has RDMA device $rdma_dev on link $pci_link"
-		fi
-	done
-
+	# b. Find the PCI link (domain:bus) of each ECPF
+	# c. Find the PCI link of the designated mpesw LAG master ECPF
+	# d. Pick the first ECPF whose PCI link differs from the master's link
+	# Selecting by PCI link does not depend on whether the mpesw LAG is
+	# already formed, so it works when SFs are created before esw_multiport
+	# is enabled.
+	#
+	# Fallback, only when no LAG master is designated:
+	# e. Find the RDMA device of each ECPF
+	# f. Eliminate ECPFs that have an RDMA device
+	# g. Eliminate ECPFs sharing the same PCI link as RDMA-bearing ECPFs
+	# h. Pick the first remaining ECPF
+	# Note: the fallback identifies the 2nd link only while the mpesw LAG
+	# is active (only then does the LAG slave lack its own RDMA device).
 	local target_ecpf=""
-	local on_rdma_link rdma_link
-	for dev in ${SWITCHDEV_DEVICES_LIST[@]}; do
-		# Skip if this ECPF has an RDMA device
-		rdma_dev=$(/bin/ls /sys/bus/pci/devices/${dev}/infiniband/ 2>/dev/null | head -1)
-		if [ -n "$rdma_dev" ]; then
-			continue
-		fi
-		# Skip if this ECPF is on the same PCI link as one with RDMA
-		pci_link=$(echo $dev | cut -d: -f1-2)
-		on_rdma_link=0
-		for rdma_link in $links_with_rdma; do
-			if [ "$pci_link" == "$rdma_link" ]; then
-				on_rdma_link=1
+	local dev pci_link master_link
+
+	if [ -n "$esw_multiport_device" ]; then
+		master_link=$(echo $esw_multiport_device | cut -d: -f1-2)
+		for dev in ${SWITCHDEV_DEVICES_LIST[@]}; do
+			pci_link=$(echo $dev | cut -d: -f1-2)
+			if [ "$pci_link" != "$master_link" ]; then
+				target_ecpf=$dev
 				break
 			fi
 		done
-		if [ $on_rdma_link -eq 0 ]; then
-			target_ecpf=$dev
-			break
-		fi
-	done
+	else
+		# Fallback when no LAG master is designated: pick an ECPF whose
+		# PCI link has no RDMA device.
+		local links_with_rdma="" rdma_dev rdma_link on_rdma_link
+		for dev in ${SWITCHDEV_DEVICES_LIST[@]}; do
+			pci_link=$(echo $dev | cut -d: -f1-2)
+			rdma_dev=$(/bin/ls /sys/bus/pci/devices/${dev}/infiniband/ 2>/dev/null | head -1)
+			if [ -n "$rdma_dev" ]; then
+				links_with_rdma="$links_with_rdma $pci_link"
+				debug "SNAP DMA SF: ECPF $dev has RDMA device $rdma_dev on link $pci_link"
+			fi
+		done
+		for dev in ${SWITCHDEV_DEVICES_LIST[@]}; do
+			# Skip if this ECPF has an RDMA device
+			rdma_dev=$(/bin/ls /sys/bus/pci/devices/${dev}/infiniband/ 2>/dev/null | head -1)
+			if [ -n "$rdma_dev" ]; then
+				continue
+			fi
+			# Skip if this ECPF is on the same PCI link as one with RDMA
+			pci_link=$(echo $dev | cut -d: -f1-2)
+			on_rdma_link=0
+			for rdma_link in $links_with_rdma; do
+				if [ "$pci_link" == "$rdma_link" ]; then
+					on_rdma_link=1
+					break
+				fi
+			done
+			if [ $on_rdma_link -eq 0 ]; then
+				target_ecpf=$dev
+				break
+			fi
+		done
+	fi
 
 	if [ -z "$target_ecpf" ]; then
 		debug "SNAP DMA SF: no eligible 2nd-link ECPF found, skipping"

--- a/tsbin/mlnx_bf_configure
+++ b/tsbin/mlnx_bf_configure
@@ -724,43 +724,11 @@ if (is_smartnic_mode "$ctrl_dev"); then
 		fi
 	done
 
-	# Set esw_multiport after all ECPFs have been switched to switchdev mode.
-	# This ordering ensures all eswitch instances are properly initialized
-	# before the multi-port eswitch LAG is configured (required for ASTRA).
-	#
-	# In ASTRA mode, esw_multiport must be set on:
-	# 1. The BF4 device (0xa2df) — for N-S multi-port eswitch (SD or Lupine dual-link)
-	# 2. The last ECPF of EVERY CX-9 SuperNIC (0x1025) — for E-W multi-plane LAG,
-	#    only when LAG_RESOURCE_ALLOCATION is PRE_ALLOCATION(1)
-	# Both coexist on Grace in ASTRA configurations.
-
-	# BF4 (N-S) esw_multiport
-	if [ -n "$esw_multiport_device" ]; then
-		if [ "X${ENABLE_ESWITCH_MULTIPORT}" == "Xyes" ]; then
-			info "Enabling ESW Multiport on BF4 device $esw_multiport_device"
-			set_dev_param ${esw_multiport_device} esw_multiport 1 "ESW Multiport:"
-		else
-			if is_sd_mode ${esw_multiport_device}; then
-				info "Enabling ESW Multiport for SD device $esw_multiport_device"
-				set_dev_param ${esw_multiport_device} esw_multiport 1 "ESW Multiport:"
-			fi
-		fi
-	fi
-
-	# CX-9 (E-W) esw_multiport — one per physical SuperNIC (last ECPF on each PCI domain:bus)
-	if [ ${#CX9_DEV_LAST_ECPF[@]} -gt 0 ]; then
-		if [ "X${ENABLE_ESWITCH_MULTIPORT}" == "Xyes" ]; then
-			for cx9_dev in $(echo "${!CX9_DEV_LAST_ECPF[@]}" | tr ' ' '\n' | sort); do
-				lag_master="${CX9_DEV_LAST_ECPF[$cx9_dev]}"
-				if is_lag_resource_pre_allocation ${lag_master}; then
-					info "Enabling ESW Multiport on last CX-9 ECPF $lag_master (device $cx9_dev)"
-					set_dev_param ${lag_master} esw_multiport 1 "ESW Multiport:"
-				else
-					info "Skipping ESW Multiport on CX-9 ECPF $lag_master (device $cx9_dev): LAG_RESOURCE_ALLOCATION is not PRE_ALLOCATION(1)"
-				fi
-			done
-		fi
-	fi
+	# NOTE: esw_multiport is enabled later, after SF creation. Creating an SF
+	# on a device that is already a member of a multi-port eswitch LAG is
+	# rejected by some kernels (devlink: "Invalid controller supplied"), so
+	# all SFs must exist before the LAG is configured. See the deferred
+	# "Enable ESW Multiport" section below.
 
 	start_ipsec_services
 fi
@@ -942,13 +910,18 @@ create_snap_dma_sf()
 	fi
 
 	# Create SF with RoCE disabled, no netdev
-	mlnx-sf --action create --device $target_ecpf \
+	local create_output
+	create_output=$(mlnx-sf --action create --device $target_ecpf \
 		--sfnum $SNAP_DMA_SF_NUM \
 		--hwaddr $snap_dma_sf_mac \
-		--disable-roce 2>/dev/null
+		--disable-roce 2>&1)
 	local rc=$?
 	if [ $rc -ne 0 ]; then
-		debug "SNAP DMA SF on $target_ecpf sfnum=$SNAP_DMA_SF_NUM may already exist or failed (rc=$rc)"
+		if (devlink port show 2>/dev/null | grep -q "pci/${target_ecpf}/[0-9]*: .* sfnum ${SNAP_DMA_SF_NUM} "); then
+			info "SNAP DMA SF on $target_ecpf sfnum=$SNAP_DMA_SF_NUM already exists"
+		else
+			error "Failed to create SNAP DMA SF on $target_ecpf sfnum=$SNAP_DMA_SF_NUM (rc=$rc): $create_output"
+		fi
 		return 1
 	fi
 
@@ -1041,6 +1014,57 @@ if [ -f /etc/mellanox/mlnx-sf.conf ]; then
 		sleep 0.1
 	done
 	. /etc/mellanox/mlnx-sf.conf
+
+	# Verify that every SF requested in mlnx-sf.conf was actually created.
+	# The commands above are sourced, so their failures are otherwise
+	# invisible in the system log.
+	while read -r sf_dev sf_num; do
+		if ! (devlink port show 2>/dev/null | grep -q "pci/${sf_dev}/[0-9]*: .* sfnum ${sf_num} \?"); then
+			error "SF sfnum=${sf_num} on ${sf_dev} requested in /etc/mellanox/mlnx-sf.conf was not created"
+		fi
+	done < <(grep -oE -- '--device +[0-9a-fA-F:.]+ +--sfnum +[0-9]+' /etc/mellanox/mlnx-sf.conf 2>/dev/null | awk '{print $2, $4}')
+fi
+
+# Enable ESW Multiport after all ECPFs are in switchdev mode AND after all
+# SFs have been created:
+# - all eswitch instances must be initialized before the multi-port eswitch
+#   LAG is configured (required for ASTRA);
+# - SF creation on a device that is already an mpesw LAG member is rejected
+#   by some kernels (devlink: "Invalid controller supplied"), so the LAG must
+#   only be formed once the SFs exist.
+#
+# In ASTRA mode, esw_multiport must be set on:
+# 1. The BF4 device (0xa2df) — for N-S multi-port eswitch (SD or Lupine dual-link)
+# 2. The last ECPF of EVERY CX-9 SuperNIC (0x1025) — for E-W multi-plane LAG,
+#    only when LAG_RESOURCE_ALLOCATION is PRE_ALLOCATION(1)
+# Both coexist on Grace in ASTRA configurations.
+
+# BF4 (N-S) esw_multiport
+if [ -n "$esw_multiport_device" ]; then
+	if [ "X${ENABLE_ESWITCH_MULTIPORT}" == "Xyes" ]; then
+		info "Enabling ESW Multiport on BF4 device $esw_multiport_device"
+		set_dev_param ${esw_multiport_device} esw_multiport 1 "ESW Multiport:"
+	else
+		if is_sd_mode ${esw_multiport_device}; then
+			info "Enabling ESW Multiport for SD device $esw_multiport_device"
+			set_dev_param ${esw_multiport_device} esw_multiport 1 "ESW Multiport:"
+		fi
+	fi
+fi
+
+# CX-9 (E-W) esw_multiport — one per physical SuperNIC (last ECPF on each PCI domain:bus)
+if [ ${#CX9_DEV_LAST_ECPF[@]} -gt 0 ]; then
+	if [ "X${ENABLE_ESWITCH_MULTIPORT}" == "Xyes" ]; then
+		for cx9_dev in $(echo "${!CX9_DEV_LAST_ECPF[@]}" | tr ' ' '\n' | sort); do
+			lag_master="${CX9_DEV_LAST_ECPF[$cx9_dev]}"
+			if is_lag_resource_pre_allocation ${lag_master}; then
+				info "Enabling ESW Multiport on last CX-9 ECPF $lag_master (device $cx9_dev)"
+				set_dev_param ${lag_master} esw_multiport 1 "ESW Multiport:"
+			else
+				info "Skipping ESW Multiport on CX-9 ECPF $lag_master (device $cx9_dev): LAG_RESOURCE_ALLOCATION is not PRE_ALLOCATION(1)"
+			fi
+		done
+	fi
 fi
 
 HUGEPAGES_TOOL=/usr/sbin/doca-hugepages


### PR DESCRIPTION
On BF4 dual-link setups, enabling esw_multiport forms the multi-port eswitch (mpesw) LAG between the two PCI links before SFs are created.
On kernels that reject SF creation on an mpesw LAG member (devlink port add fails with "Invalid controller supplied", 
observed with the OracleLinux 9 inbox BlueField kernel), every SF targeted at the second
link then silently fails: both the SNAP DMA SF and the default SF from /etc/mellanox/mlnx-sf.conf are missing, 
leaving the second host PF without its default SF and representor. 
The failures were invisible because the SNAP creation discards stderr and logs only at debug level,
and the mlnx-sf.conf commands are sourced with no error reporting.

Defer the ESW multiport configuration until after SF creation. SFs created before the LAG is formed persist 
and function correctly once the mpesw LAG is established. Make SF creation failures visible: log an
error with the tool output when the SNAP DMA SF creation fails (keeping the already-exists case at info level), 
and verify after sourcing mlnx-sf.conf that every requested SF exists, logging an error for each one that does not.

The SNAP DMA SF target selection is also updated to pick the ECPF by PCI link 
(the link that differs from the designated LAG master) instead of the ECPF with no RDMA device, 
which is only true for the LAG slave while the LAG is active and therefore finds no target under the new ordering. 
The RDMA-based heuristic is kept as a fallback when no LAG master is designated.

Issue: 5224984